### PR TITLE
Fix assertion failure while selecting variable

### DIFF
--- a/Sources/Fuzzilli/Core/ProgramBuilder.swift
+++ b/Sources/Fuzzilli/Core/ProgramBuilder.swift
@@ -1657,7 +1657,7 @@ public class ProgramBuilder {
             probesWeaved += 1
         }
         guard Double(probesWeaved) < fuzzer.config.differentialWeaveRate * Double(code.count) else { return }
-        if probability(fuzzer.config.differentialWeaveRate) {
+        if probability(fuzzer.config.differentialWeaveRate) && hasVisibleVariables {
             //guard scopeAnalyzer.visibleVariables.count > 0 else { return }
             code.append(Instruction(DifferentialHash(allowInnerScope: true), inouts: [randVar()]))
             probesWeaved += 1


### PR DESCRIPTION
```bash
swift run FuzzilliCli --overwrite --storagePath=fuzzout --exportStatistics --logLevel=verbose --diagnostics --differentialWeaveRate=0.5 --profile=spidermonkey ./Cloud/Docker/SpidermonkeyBuilder/out/js

# ...
[Fuzzer] Initialized
[Assert] Debug Assertion failed at /home/user/JIT-Picker/Sources/Fuzzilli/Core/ProgramBuilder.swift:328
[Fuzzer] Shutting down due to fatal error

++++++++++ Fuzzer Finished ++++++++++
# ...
```

```swift
    /// Returns a random variable.
    public func randVar(excludeInnermostScope: Bool = false) -> Variable {
        Assert(hasVisibleVariables) // <-- assertion failure here
        return randVarInternal(excludeInnermostScope: excludeInnermostScope)!
    }
```